### PR TITLE
Removing symbolic link file created by `os.symlink`

### DIFF
--- a/test/test_stowage.py
+++ b/test/test_stowage.py
@@ -169,6 +169,7 @@ class TestPathGenerators:
             (join(self.dir, '_config/openbox/openbox.xml'),
                 join(self.dir, '.config/openbox/openbox.xml')),
         ])
+        os.remove(join(self.dir, '.vimrc'))
 
 
 class TestFullBehavior:


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_partially_needed_symlink_walk` by removing symbolic link file created by `os.symlink` by calling method `os.remove`

The test can fail in this way if symbolic file is not removed:
```
>       os.symlink(__file__, join(self.dir, '.vimrc'))
E       FileExistsError: [Errno 17] File exists: '/home/ailen/PycharmProjects/stowage/test/test_stowage.py' -> '/tmp/tmp_stowage_test_44omn0jn/.vimrc'